### PR TITLE
Strip non-alphanumeric from disk serials

### DIFF
--- a/disklist.pl
+++ b/disklist.pl
@@ -178,6 +178,7 @@ sub parseDisks {
       if ( $line =~ m/^[\s]*ident:/ ) {
          $serial =  $line;
          $serial =~ s/^.*:[\s]*(.*)[\s]*$/$1/;
+         $serial =~ s/[^a-zA-Z0-9]//g;
          if ( $device ne "" ) { $disk->{ 'serial' } = $serial; }
       }
    }
@@ -609,6 +610,7 @@ sub parseSasDevices {
              if( $line =~ m/Serial No/ ) {
                 $disk->{'serial'} = $line;
                 $disk->{'serial'} =~ s/^.*:[ ]+([^ ]*).*$/$1/;
+                $disk->{'serial'} =~ s/[^a-zA-Z0-9]//g;
              }             
              if( $line =~ m/Drive Type/ ) {
                 $disk->{'type'} = $line;


### PR DESCRIPTION
Strip non-alphanumeric from disk serials to allow for WD ATA disks on a SAS controller to be matched with results of `geom disk list`

Example outputs:
```bash
# geom disk list da34
Geom name: da34
Providers:
1. Name: da34
   Mediasize: 4000787030016 (3.6T)
   Sectorsize: 512
   Mode: r1w1e3
   descr: ATA WDC WD4001FAEX-0
   lunid: 50014ee0aeaaaaaa
   ident: WD-WMC1F0123456
   rotationrate: unknown
   fwsectors: 63
   fwheads: 255
```

```bash
# sas2ircu 2 display
Device is a Hard disk
  Enclosure #                             : 1
  Slot #                                  : 3
  SAS Address                             : 4433221-1-0000-0000
  State                                   : Ready (RDY)
  Size (in MB)/(in sectors)               : 3815447/7814037167
  Manufacturer                            : ATA
  Model Number                            : WDC WD4001FAEX-0
  Firmware Revision                       : 1L01
  Serial No                               : WDWMC1F0123456
  GUID                                    : N/A
  Protocol                                : SATA
  Drive Type                              : SATA_HDD
```

This patch will also make locate function in this setup.